### PR TITLE
Allow buttons in project section to auto adjust width to fit text

### DIFF
--- a/src/styles/_projects.scss
+++ b/src/styles/_projects.scss
@@ -69,7 +69,7 @@
 
 .project-link {
   display: block;
-  width: 100px;
+  display: inline-block;
   margin: 10px 0px;
   padding: 5px;
   color: $main;


### PR DESCRIPTION
The is the best Jekyll Theme I've seen so far :+1: Our team as adopted it as our product official site. Thank you for this great work :+1: 

Just a little suggestion on this perfect package. If text is long, it extend outside of the button. This fix should handle that.